### PR TITLE
Mount a persistent docker volume in place of your local node_modules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,12 +42,12 @@ services:
     container_name: django_elasticsearch_dsl_drf_frontend
     image: django_elasticsearch_dsl_drf_frontend:latest
     build:
-      context: .
-      dockerfile: ./docker/frontend/Dockerfile
-    command: bash -l -c "cd /frontend/examples/frontend/ && yarn dev"
+      context: ./examples/frontend/
+      dockerfile: ../../docker/frontend/Dockerfile
+    command: bash -l -c "cd /frontend/ && yarn dev"
     volumes:
-      - .:/frontend
-      - /frontend/node_modules
+      - ./examples/frontend/:/frontend
+      - node_modules:/frontend/node_modules
     ports:
       - "3000:3000"
     depends_on:
@@ -57,3 +57,4 @@ services:
 volumes:
   data:
   esdata:
+  node_modules:

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get install -y nano
 
 RUN mkdir /frontend
 
-ADD examples/frontend/package.json /frontend/
+ADD package.json /frontend/
 ADD . /frontend/
 
 WORKDIR /frontend


### PR DESCRIPTION
#### Problem
- The issue was that mounting an empty `node_modules` from inside the repo was overriding the `node_modules` inside the image(which has the packages.

#### Solution
- Mount a different volume that will be persisted(which is the point of using volumes).
- A minor caveat is if you want to have the node_modules on host i.e inside `examples/frontend` you'll have to do a yarn/npm install inside the directory in your host machine.