### PR TITLE
prevent unicode errors

### DIFF
--- a/examples/simple/factories/constants.py
+++ b/examples/simple/factories/constants.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 __all__ = (
     'BOOK_GENRES',


### PR DESCRIPTION
Fix error described in #128 

I've created travis config with ubuntu xenial worker and run tests with it. I've got same error with unicode and python2:

https://travis-ci.org/ar7n/django-elasticsearch-dsl-drf/builds/528248420

After this commit was merged, error has gone:

https://travis-ci.org/ar7n/django-elasticsearch-dsl-drf/builds/528257334

(4.2 job failed due strange error which i randomly get sometimes)