### PR TITLE
Add support for django-elasticsearch-dsl 6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     python: 3.7
 
 before_install:
-  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.16.deb && sudo dpkg -i --force-confnew elasticsearch-5.6.16.deb && sudo service elasticsearch restart
+  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.5.4.deb && sudo dpkg -i --force-confnew elasticsearch-6.5.4.deb && sudo service elasticsearch restart
 
 install: pip install -r examples/requirements/test.txt
 

--- a/docs/advanced_usage_examples.rst
+++ b/docs/advanced_usage_examples.rst
@@ -234,7 +234,7 @@ Document index
 .. code-block:: python
 
     from django.conf import settings
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
     from elasticsearch_dsl import analyzer
 
     from books.models import Book
@@ -257,7 +257,7 @@ Document index
 
 
     @INDEX.doc_type
-    class BookDocument(DocType):
+    class BookDocument(Document):
         """Book Elasticsearch document."""
 
         id = fields.IntegerField(attr='id')
@@ -326,7 +326,7 @@ Document index
         class Meta(object):
             """Meta options."""
 
-            model = Book  # The model associate with this DocType
+            model = Book  # The model associate with this Document
 
 Sample serializer
 -----------------
@@ -964,7 +964,7 @@ documents using ``fields.CompletionField``.
 
     from django.conf import settings
 
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
 
     from books.models import Publisher
 
@@ -979,7 +979,7 @@ documents using ``fields.CompletionField``.
 
 
     @INDEX.doc_type
-    class PublisherDocument(DocType):
+    class PublisherDocument(Document):
         """Publisher Elasticsearch document."""
 
         id = fields.IntegerField(attr='id')
@@ -1028,7 +1028,7 @@ documents using ``fields.CompletionField``.
         class Meta(object):
             """Meta options."""
 
-            model = Publisher  # The model associate with this DocType
+            model = Publisher  # The model associate with this Document
 
 After that the ``name.suggest``, ``city.suggest``, ``state_province.suggest``
 and ``country.suggest`` fields would be available for suggestions feature.
@@ -1324,7 +1324,7 @@ In that case, the document definition should be altered as follows:
 
 .. code-block:: python
 
-    class BookDocument(DocType):
+    class BookDocument(Document):
 
         # ...
 
@@ -1418,7 +1418,7 @@ In that case, the document definition should be altered as follows:
 
 .. code-block:: python
 
-    class AddressDocument(DocType):
+    class AddressDocument(Document):
 
         # ...
 
@@ -1513,7 +1513,7 @@ Document definition
 
     from django.conf import settings
 
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
 
     from books.models import Book
 
@@ -1527,7 +1527,7 @@ Document definition
     )
 
     @INDEX.doc_type
-    class BookDocument(DocType):
+    class BookDocument(Document):
         """Book Elasticsearch document."""
         # ID
         id = fields.IntegerField(attr='id')
@@ -1608,7 +1608,7 @@ Document definition
         class Meta(object):
             """Meta options."""
 
-            model = Book  # The model associate with this DocType
+            model = Book  # The model associate with this Document
 
 ViewSet definition
 ^^^^^^^^^^^^^^^^^^
@@ -2022,7 +2022,7 @@ The following example indicates Ngram analyzer/filter usage.
 .. code-block:: python
 
     from django.conf import settings
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
 
     from elasticsearch_dsl import analyzer
     from elasticsearch_dsl.analysis import token_filter
@@ -2052,7 +2052,7 @@ The following example indicates Ngram analyzer/filter usage.
     )
 
     @INDEX.doc_type
-    class BookDocument(DocType):
+    class BookDocument(Document):
         """Book Elasticsearch document."""
 
         # In different parts of the code different fields are used. There are
@@ -2083,7 +2083,7 @@ The following example indicates Ngram analyzer/filter usage.
         class Meta(object):
             """Meta options."""
 
-            model = Book  # The model associate with this DocType
+            model = Book  # The model associate with this Document
 
 ViewSet definition
 ~~~~~~~~~~~~~~~~~~

--- a/docs/basic_usage_examples.rst
+++ b/docs/basic_usage_examples.rst
@@ -77,7 +77,7 @@ Sample document
 
 .. code-block:: python
 
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
     from elasticsearch_dsl import analyzer
 
     from books.models import Publisher
@@ -92,7 +92,7 @@ Sample document
 
 
     @PUBLISHER_INDEX.doc_type
-    class PublisherDocument(DocType):
+    class PublisherDocument(Document):
         """Publisher Elasticsearch document."""
 
         id = fields.IntegerField(attr='id')
@@ -135,7 +135,7 @@ Sample document
         class Meta(object):
             """Meta options."""
 
-            model = Publisher  # The model associate with this DocType
+            model = Publisher  # The model associate with this Document
 
 
 Sample serializer

--- a/docs/indexing_troubleshooting.rst
+++ b/docs/indexing_troubleshooting.rst
@@ -94,7 +94,7 @@ document meta.
 
 .. code-block:: python
 
-    class LocationDocument(DocType):
+    class LocationDocument(Document):
 
         # ...
 
@@ -116,7 +116,7 @@ wish to index them by chunks of 20 thousands at once, specify the
 
 .. code-block:: python
 
-    class LocationDocument(DocType):
+    class LocationDocument(Document):
 
         # ...
 
@@ -153,7 +153,7 @@ settings (as already has been mentioned above).
 
     # ...
 
-    class LocationDocument(DocType):
+    class LocationDocument(Document):
 
         # ...
 

--- a/docs/more_like_this.rst
+++ b/docs/more_like_this.rst
@@ -12,7 +12,7 @@ Sample document
 
     from django.conf import settings
 
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
     from django_elasticsearch_dsl_drf.compat import KeywordField, StringField
     from django_elasticsearch_dsl_drf.analyzers import edge_ngram_completion
 
@@ -31,7 +31,7 @@ Sample document
 
 
     @INDEX.doc_type
-    class BookDocument(DocType):
+    class BookDocument(Document):
 
         # ID
         id = fields.IntegerField(attr='id')
@@ -69,7 +69,7 @@ Sample document
         class Meta(object):
             """Meta options."""
 
-            model = Book  # The model associate with this DocType
+            model = Book  # The model associate with this Document
 
         def prepare_summary(self, instance):
             """Prepare summary."""

--- a/docs/nested_fields_usage_examples.rst
+++ b/docs/nested_fields_usage_examples.rst
@@ -335,7 +335,7 @@ Document index
 
     from django.conf import settings
 
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
     from django_elasticsearch_dsl_drf.compat import KeywordField, StringField
 
     from books.models import Address
@@ -352,7 +352,7 @@ Document index
     )
 
     @INDEX.doc_type
-    class AddressDocument(DocType):
+    class AddressDocument(Document):
         """Address Elasticsearch document."""
 
         # In different parts of the code different fields are used. There are
@@ -484,7 +484,7 @@ Document index
         class Meta(object):
             """Meta options."""
 
-            model = Address  # The model associate with this DocType
+            model = Address  # The model associate with this Document
 
 Sample serializer
 -----------------
@@ -765,7 +765,7 @@ Sample document
 
     from django.conf import settings
 
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
     from django_elasticsearch_dsl_drf.compat import KeywordField, StringField
 
     from books.models import City
@@ -782,7 +782,7 @@ Sample document
 
 
     @INDEX.doc_type
-    class CityDocument(DocType):
+    class CityDocument(Document):
         """City Elasticsearch document.
 
         This document has been created purely for testing out complex fields.
@@ -847,7 +847,7 @@ Sample document
         class Meta(object):
             """Meta options."""
 
-            model = City  # The model associate with this DocType
+            model = City  # The model associate with this Document
 
 Sample view
 +++++++++++

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -393,7 +393,7 @@ Required imports
 .. code-block:: python
 
     from django.conf import settings
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
     from elasticsearch_dsl import analyzer
 
     from books.models import Book
@@ -488,7 +488,7 @@ Document definition
 .. code-block:: python
 
     @INDEX.doc_type
-    class BookDocument(DocType):
+    class BookDocument(Document):
         """Book Elasticsearch document."""
 
         id = fields.IntegerField(attr='id')
@@ -557,7 +557,7 @@ Document definition
         class Meta(object):
             """Meta options."""
 
-            model = Book  # The model associate with this DocType
+            model = Book  # The model associate with this Document
 
 Syncing Django's database with Elasticsearch indexes
 ----------------------------------------------------
@@ -1081,7 +1081,7 @@ Change your development settings in the following way:
 
 .. code-block:: python
 
-    MIDDLEWARE_CLASSES += (
+    MIDDLEWARE += (
         'debug_toolbar.middleware.DebugToolbarMiddleware',
         'debug_toolbar_force.middleware.ForceDebugToolbarMiddleware',
     )

--- a/docs_src/advanced_usage_examples.rst
+++ b/docs_src/advanced_usage_examples.rst
@@ -234,7 +234,7 @@ Document index
 .. code-block:: python
 
     from django.conf import settings
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
     from elasticsearch_dsl import analyzer
 
     from books.models import Book
@@ -257,7 +257,7 @@ Document index
 
 
     @INDEX.doc_type
-    class BookDocument(DocType):
+    class BookDocument(Document):
         """Book Elasticsearch document."""
 
         id = fields.IntegerField(attr='id')
@@ -326,7 +326,7 @@ Document index
         class Meta(object):
             """Meta options."""
 
-            model = Book  # The model associate with this DocType
+            model = Book  # The model associate with this Document
 
 Sample serializer
 -----------------
@@ -964,7 +964,7 @@ documents using ``fields.CompletionField``.
 
     from django.conf import settings
 
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
 
     from books.models import Publisher
 
@@ -979,7 +979,7 @@ documents using ``fields.CompletionField``.
 
 
     @INDEX.doc_type
-    class PublisherDocument(DocType):
+    class PublisherDocument(Document):
         """Publisher Elasticsearch document."""
 
         id = fields.IntegerField(attr='id')
@@ -1028,7 +1028,7 @@ documents using ``fields.CompletionField``.
         class Meta(object):
             """Meta options."""
 
-            model = Publisher  # The model associate with this DocType
+            model = Publisher  # The model associate with this Document
 
 After that the ``name.suggest``, ``city.suggest``, ``state_province.suggest``
 and ``country.suggest`` fields would be available for suggestions feature.
@@ -1324,7 +1324,7 @@ In that case, the document definition should be altered as follows:
 
 .. code-block:: python
 
-    class BookDocument(DocType):
+    class BookDocument(Document):
 
         # ...
 
@@ -1418,7 +1418,7 @@ In that case, the document definition should be altered as follows:
 
 .. code-block:: python
 
-    class AddressDocument(DocType):
+    class AddressDocument(Document):
 
         # ...
 
@@ -1513,7 +1513,7 @@ Document definition
 
     from django.conf import settings
 
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
 
     from books.models import Book
 
@@ -1527,7 +1527,7 @@ Document definition
     )
 
     @INDEX.doc_type
-    class BookDocument(DocType):
+    class BookDocument(Document):
         """Book Elasticsearch document."""
         # ID
         id = fields.IntegerField(attr='id')
@@ -1608,7 +1608,7 @@ Document definition
         class Meta(object):
             """Meta options."""
 
-            model = Book  # The model associate with this DocType
+            model = Book  # The model associate with this Document
 
 ViewSet definition
 ^^^^^^^^^^^^^^^^^^
@@ -2022,7 +2022,7 @@ The following example indicates Ngram analyzer/filter usage.
 .. code-block:: python
 
     from django.conf import settings
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
 
     from elasticsearch_dsl import analyzer
     from elasticsearch_dsl.analysis import token_filter
@@ -2052,7 +2052,7 @@ The following example indicates Ngram analyzer/filter usage.
     )
 
     @INDEX.doc_type
-    class BookDocument(DocType):
+    class BookDocument(Document):
         """Book Elasticsearch document."""
 
         # In different parts of the code different fields are used. There are
@@ -2083,7 +2083,7 @@ The following example indicates Ngram analyzer/filter usage.
         class Meta(object):
             """Meta options."""
 
-            model = Book  # The model associate with this DocType
+            model = Book  # The model associate with this Document
 
 ViewSet definition
 ~~~~~~~~~~~~~~~~~~

--- a/docs_src/basic_usage_examples.rst
+++ b/docs_src/basic_usage_examples.rst
@@ -77,7 +77,7 @@ Sample document
 
 .. code-block:: python
 
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
     from elasticsearch_dsl import analyzer
 
     from books.models import Publisher
@@ -92,7 +92,7 @@ Sample document
 
 
     @PUBLISHER_INDEX.doc_type
-    class PublisherDocument(DocType):
+    class PublisherDocument(Document):
         """Publisher Elasticsearch document."""
 
         id = fields.IntegerField(attr='id')
@@ -135,7 +135,7 @@ Sample document
         class Meta(object):
             """Meta options."""
 
-            model = Publisher  # The model associate with this DocType
+            model = Publisher  # The model associate with this Document
 
 
 Sample serializer

--- a/docs_src/indexing_troubleshooting.rst
+++ b/docs_src/indexing_troubleshooting.rst
@@ -94,7 +94,7 @@ document meta.
 
 .. code-block:: python
 
-    class LocationDocument(DocType):
+    class LocationDocument(Document):
 
         # ...
 
@@ -116,7 +116,7 @@ wish to index them by chunks of 20 thousands at once, specify the
 
 .. code-block:: python
 
-    class LocationDocument(DocType):
+    class LocationDocument(Document):
 
         # ...
 
@@ -153,7 +153,7 @@ settings (as already has been mentioned above).
 
     # ...
 
-    class LocationDocument(DocType):
+    class LocationDocument(Document):
 
         # ...
 

--- a/docs_src/more_like_this.rst
+++ b/docs_src/more_like_this.rst
@@ -12,7 +12,7 @@ Sample document
 
     from django.conf import settings
 
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
     from django_elasticsearch_dsl_drf.compat import KeywordField, StringField
     from django_elasticsearch_dsl_drf.analyzers import edge_ngram_completion
 
@@ -31,7 +31,7 @@ Sample document
 
 
     @INDEX.doc_type
-    class BookDocument(DocType):
+    class BookDocument(Document):
 
         # ID
         id = fields.IntegerField(attr='id')
@@ -69,7 +69,7 @@ Sample document
         class Meta(object):
             """Meta options."""
 
-            model = Book  # The model associate with this DocType
+            model = Book  # The model associate with this Document
 
         def prepare_summary(self, instance):
             """Prepare summary."""

--- a/docs_src/nested_fields_usage_examples.rst
+++ b/docs_src/nested_fields_usage_examples.rst
@@ -335,7 +335,7 @@ Document index
 
     from django.conf import settings
 
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
     from django_elasticsearch_dsl_drf.compat import KeywordField, StringField
 
     from books.models import Address
@@ -352,7 +352,7 @@ Document index
     )
 
     @INDEX.doc_type
-    class AddressDocument(DocType):
+    class AddressDocument(Document):
         """Address Elasticsearch document."""
 
         # In different parts of the code different fields are used. There are
@@ -484,7 +484,7 @@ Document index
         class Meta(object):
             """Meta options."""
 
-            model = Address  # The model associate with this DocType
+            model = Address  # The model associate with this Document
 
 Sample serializer
 -----------------
@@ -765,7 +765,7 @@ Sample document
 
     from django.conf import settings
 
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
     from django_elasticsearch_dsl_drf.compat import KeywordField, StringField
 
     from books.models import City
@@ -782,7 +782,7 @@ Sample document
 
 
     @INDEX.doc_type
-    class CityDocument(DocType):
+    class CityDocument(Document):
         """City Elasticsearch document.
 
         This document has been created purely for testing out complex fields.
@@ -847,7 +847,7 @@ Sample document
         class Meta(object):
             """Meta options."""
 
-            model = City  # The model associate with this DocType
+            model = City  # The model associate with this Document
 
 Sample view
 +++++++++++

--- a/docs_src/quick_start.rst
+++ b/docs_src/quick_start.rst
@@ -393,7 +393,7 @@ Required imports
 .. code-block:: python
 
     from django.conf import settings
-    from django_elasticsearch_dsl import DocType, Index, fields
+    from django_elasticsearch_dsl import Document, Index, fields
     from elasticsearch_dsl import analyzer
 
     from books.models import Book
@@ -488,7 +488,7 @@ Document definition
 .. code-block:: python
 
     @INDEX.doc_type
-    class BookDocument(DocType):
+    class BookDocument(Document):
         """Book Elasticsearch document."""
 
         id = fields.IntegerField(attr='id')
@@ -557,7 +557,7 @@ Document definition
         class Meta(object):
             """Meta options."""
 
-            model = Book  # The model associate with this DocType
+            model = Book  # The model associate with this Document
 
 Syncing Django's database with Elasticsearch indexes
 ----------------------------------------------------
@@ -1081,7 +1081,7 @@ Change your development settings in the following way:
 
 .. code-block:: python
 
-    MIDDLEWARE_CLASSES += (
+    MIDDLEWARE += (
         'debug_toolbar.middleware.DebugToolbarMiddleware',
         'debug_toolbar_force.middleware.ForceDebugToolbarMiddleware',
     )

--- a/examples/requirements/common.txt
+++ b/examples/requirements/common.txt
@@ -1,7 +1,5 @@
 -r elastic.txt
 
-#mysqlclient
-psycopg2
 python-memcached==1.58
 pytz
 six>=1.9

--- a/examples/requirements/elastic.txt
+++ b/examples/requirements/elastic.txt
@@ -1,1 +1,1 @@
--r elastic_5x.txt
+-r elastic_6x.txt

--- a/examples/requirements/elastic_6x.txt
+++ b/examples/requirements/elastic_6x.txt
@@ -1,4 +1,3 @@
 elasticsearch==6.3.0
-elasticsearch-dsl==6.1.0
-#elasticsearch-dsl==6.2.1
-django-elasticsearch-dsl==0.5.0
+elasticsearch-dsl==6.4.0
+django-elasticsearch-dsl==6.4.2

--- a/examples/simple/search_indexes/documents/address.py
+++ b/examples/simple/search_indexes/documents/address.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from django_elasticsearch_dsl import DocType, Index, fields
+from django_elasticsearch_dsl import Document, Index, fields
 from django_elasticsearch_dsl_drf.compat import KeywordField, StringField
 from django_elasticsearch_dsl_drf.versions import ELASTICSEARCH_GTE_5_0
 
@@ -23,7 +23,7 @@ INDEX.settings(
 
 
 @INDEX.doc_type
-class AddressDocument(DocType):
+class AddressDocument(Document):
     """Address Elasticsearch document."""
 
     # In different parts of the code different fields are used. There are
@@ -174,10 +174,10 @@ class AddressDocument(DocType):
         attr='location_field_indexing',
     )
 
-    class Meta(object):
-        """Meta options."""
+    class Django(object):
+        model = Address  # The model associate with this Document
 
-        model = Address  # The model associate with this DocType
+    class Meta(object):
         parallel_indexing = True
         # queryset_pagination = 500000  # This will split the queryset
         #                               # into parts while indexing

--- a/examples/simple/search_indexes/documents/author.py
+++ b/examples/simple/search_indexes/documents/author.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from django_elasticsearch_dsl import DocType, Index, fields
+from django_elasticsearch_dsl import Document, Index, fields
 from django_elasticsearch_dsl_drf.compat import KeywordField, StringField
 from django_elasticsearch_dsl_drf.analyzers import edge_ngram_completion
 
@@ -20,7 +20,7 @@ INDEX.settings(
 
 
 @INDEX.doc_type
-class AuthorDocument(DocType):
+class AuthorDocument(Document):
     """Author Elasticsearch document."""
 
     id = fields.IntegerField(attr='id')
@@ -61,9 +61,9 @@ class AuthorDocument(DocType):
 
     headshot = StringField(attr='headshot_indexing')
 
-    class Meta(object):
-        """Meta options."""
+    class Django(object):
+        model = Author  # The model associate with this Document
 
-        model = Author  # The model associate with this DocType
+    class Meta(object):
         parallel_indexing = True
         # queryset_pagination = 50  # This stands for `chunk_size`

--- a/examples/simple/search_indexes/documents/book.py
+++ b/examples/simple/search_indexes/documents/book.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from django_elasticsearch_dsl import DocType, Index, fields
+from django_elasticsearch_dsl import Document, Index, fields
 from django_elasticsearch_dsl_drf.compat import KeywordField, StringField
 from django_elasticsearch_dsl_drf.analyzers import edge_ngram_completion
 from django_elasticsearch_dsl_drf.versions import ELASTICSEARCH_GTE_5_0
@@ -24,7 +24,7 @@ INDEX.settings(
 
 
 @INDEX.doc_type
-class BookDocument(DocType):
+class BookDocument(Document):
     """Book Elasticsearch document."""
 
     # In different parts of the code different fields are used. There are
@@ -160,10 +160,10 @@ class BookDocument(DocType):
 
     null_field = StringField(attr='null_field_indexing')
 
-    class Meta(object):
-        """Meta options."""
+    class Django(object):
+        model = Book  # The model associate with this Document
 
-        model = Book  # The model associate with this DocType
+    class Meta(object):
         parallel_indexing = True
         # queryset_pagination = 50  # This will split the queryset
         #                           # into parts while indexing
@@ -175,3 +175,4 @@ class BookDocument(DocType):
     def prepare_authors(self, instance):
         """Prepare authors."""
         return [author.name for author in instance.authors.all()]
+

--- a/examples/simple/search_indexes/documents/city.py
+++ b/examples/simple/search_indexes/documents/city.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from django_elasticsearch_dsl import DocType, Index, fields
+from django_elasticsearch_dsl import Document, Index, fields
 from django_elasticsearch_dsl_drf.compat import KeywordField, StringField
 
 from books.models import City
@@ -22,7 +22,7 @@ INDEX.settings(
 
 
 @INDEX.doc_type
-class CityDocument(DocType):
+class CityDocument(Document):
     """City Elasticsearch document.
 
     This document has been created purely for testing out complex fields.
@@ -97,10 +97,10 @@ class CityDocument(DocType):
     )
     # integer_dict_indexing
 
-    class Meta(object):
-        """Meta options."""
+    class Django(object):
+        model = City  # The model associate with this Document
 
-        model = City  # The model associate with this DocType
+    class Meta(object):
         parallel_indexing = True
         # queryset_pagination = 50  # This will split the queryset
         #                           # into parts while indexing

--- a/examples/simple/search_indexes/documents/location.py
+++ b/examples/simple/search_indexes/documents/location.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django_elasticsearch_dsl import DocType, Index, fields
+from django_elasticsearch_dsl import Document, Index, fields
 from django_elasticsearch_dsl_drf.compat import KeywordField, StringField
 from django_elasticsearch_dsl_drf.analyzers import edge_ngram_completion
 from django_elasticsearch_dsl_drf.versions import ELASTICSEARCH_GTE_5_0
@@ -26,7 +26,7 @@ html_strip = analyzer(
 
 
 @INDEX.doc_type
-class LocationDocument(DocType):
+class LocationDocument(Document):
     """
     Location document.
     """
@@ -204,10 +204,10 @@ class LocationDocument(DocType):
     revenue = fields.FloatField(attr="revenue")
     coordinates = fields.GeoPointField(attr="location_field_indexing")
 
-    class Meta(object):
-        """Meta options."""
+    class Django(object):
+        model = Location  # The model associate with this Document
 
-        model = Location  # The model associate with this DocType
+    class Meta(object):
         parallel_indexing = True
         queryset_pagination = 50  # This will split the queryset
                                   # into parts while indexing

--- a/examples/simple/search_indexes/documents/publisher.py
+++ b/examples/simple/search_indexes/documents/publisher.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from django_elasticsearch_dsl import DocType, Index, fields
+from django_elasticsearch_dsl import Document, Index, fields
 from django_elasticsearch_dsl_drf.compat import KeywordField, StringField
 from django_elasticsearch_dsl_drf.analyzers import edge_ngram_completion
 
@@ -20,7 +20,7 @@ INDEX.settings(
 
 
 @INDEX.doc_type
-class PublisherDocument(DocType):
+class PublisherDocument(Document):
     """Publisher Elasticsearch document."""
 
     id = fields.IntegerField(attr='id')
@@ -78,10 +78,10 @@ class PublisherDocument(DocType):
     # Location
     location = fields.GeoPointField(attr='location_field_indexing')
 
-    class Meta(object):
-        """Meta options."""
+    class Django(object):
+        model = Publisher  # The model associate with this Document
 
-        model = Publisher  # The model associate with this DocType
+    class Meta(object):
         parallel_indexing = True
         # queryset_pagination = 50  # This will split the queryset
         #                           # into parts while indexing

--- a/examples/simple/settings/base.py
+++ b/examples/simple/settings/base.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-from nine import versions
+from django_nine import versions
 
 from .core import PROJECT_DIR, gettext
 

--- a/src/django_elasticsearch_dsl_drf/filter_backends/suggester/functional.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/suggester/functional.py
@@ -6,7 +6,7 @@ properly indexed using ``fields.CompletionField``.
 
 Example:
 
-    >>> from django_elasticsearch_dsl import DocType, Index, fields
+    >>> from django_elasticsearch_dsl import Document, Index, fields
     >>>
     >>> from books.models import Publisher
     >>>
@@ -19,7 +19,7 @@ Example:
     >>> )
     >>>
     >>> @PUBLISHER_INDEX.doc_type
-    >>> class PublisherDocument(DocType):
+    >>> class PublisherDocument(Document):
     >>>     "Publisher Elasticsearch document."
     >>>
     >>>     id = fields.IntegerField(attr='id')
@@ -65,7 +65,7 @@ Example:
     >>>     class Meta(object):
     >>>         "Meta options."
     >>>
-    >>>         model = Publisher  # The model associate with this DocType
+    >>>         model = Publisher  # The model associate with this Document
 """
 from elasticsearch_dsl.search import AggsProxy
 

--- a/src/django_elasticsearch_dsl_drf/filter_backends/suggester/native.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/suggester/native.py
@@ -6,7 +6,7 @@ properly indexed using ``fields.CompletionField``.
 
 Example:
 
-    >>> from django_elasticsearch_dsl import DocType, Index, fields
+    >>> from django_elasticsearch_dsl import Document, Index, fields
     >>>
     >>> from books.models import Publisher
     >>>
@@ -19,7 +19,7 @@ Example:
     >>> )
     >>>
     >>> @PUBLISHER_INDEX.doc_type
-    >>> class PublisherDocument(DocType):
+    >>> class PublisherDocument(Document):
     >>>     "Publisher Elasticsearch document."
     >>>
     >>>     id = fields.IntegerField(attr='id')
@@ -65,7 +65,7 @@ Example:
     >>>     class Meta(object):
     >>>         "Meta options."
     >>>
-    >>>         model = Publisher  # The model associate with this DocType
+    >>>         model = Publisher  # The model associate with this Document
 """
 
 from django_elasticsearch_dsl_drf.constants import (

--- a/src/django_elasticsearch_dsl_drf/helpers.py
+++ b/src/django_elasticsearch_dsl_drf/helpers.py
@@ -30,7 +30,7 @@ def get_document_for_model(model):
     :param model: Model to get document index for.
     :type model: Subclass of `django.db.models.Model`.
     :return: Document index for the given model.
-    :rtype: Subclass of `django_elasticsearch_dsl.DocType`.
+    :rtype: Subclass of `django_elasticsearch_dsl.Document`.
     """
     documents = registry.get_documents()
     for document in documents:
@@ -49,7 +49,7 @@ def get_index_and_mapping_for_model(model):
     document = get_document_for_model(model)
     if document is not None:
         return (
-            document.Index.name,
+            document._index._name,
             document._doc_type.mapping.properties.name
         )
 

--- a/src/django_elasticsearch_dsl_drf/serializers.py
+++ b/src/django_elasticsearch_dsl_drf/serializers.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 
 from django.core.exceptions import ImproperlyConfigured
 
-from django_elasticsearch_dsl import fields, DocType
+from django_elasticsearch_dsl import fields, Document
 
 from rest_framework import serializers
 from rest_framework.fields import empty
@@ -150,9 +150,9 @@ class DocumentSerializer(
                 "Meta class."
             )
 
-        if not issubclass(self.Meta.document, (DocType,)):
+        if not issubclass(self.Meta.document, (Document,)):
             raise ImproperlyConfigured(
-                "You must subclass the serializer 'document' from the DocType"
+                "You must subclass the serializer 'document' from the Document"
                 "class."
             )
 

--- a/src/django_elasticsearch_dsl_drf/tests/test_serializers.py
+++ b/src/django_elasticsearch_dsl_drf/tests/test_serializers.py
@@ -9,7 +9,7 @@ import unittest
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
 
-from django_elasticsearch_dsl import DocType, Index, fields
+from django_elasticsearch_dsl import Document, Index, fields
 from django_elasticsearch_dsl_drf.compat import KeywordField, StringField
 
 import pytest
@@ -43,7 +43,7 @@ class TestSerializers(BaseRestFrameworkTestCase):
         )
 
         @index.doc_type
-        class UserDocument(DocType):
+        class UserDocument(Document):
             """For testing purposes."""
 
             id = fields.IntegerField(attr='id')
@@ -81,10 +81,8 @@ class TestSerializers(BaseRestFrameworkTestCase):
 
             date_joined = fields.DateField()
 
-            class Meta(object):
-                """Meta options."""
-
-                model = User  # The model associate with this DocType
+            class Django(object):
+                model = User  # The model associate with this Document
 
         return UserDocument
 

--- a/src/django_elasticsearch_dsl_drf/viewsets.py
+++ b/src/django_elasticsearch_dsl_drf/viewsets.py
@@ -158,7 +158,7 @@ class BaseDocumentViewSet(ReadOnlyModelViewSet):
         self.client = connections.get_connection(
             self.document._get_using()
         )
-        self.index = self.document.Index.name
+        self.index = self.document._index._name
         self.mapping = self.document._doc_type.mapping.properties.name
         self.search = Search(
             using=self.client,


### PR DESCRIPTION
Well, #141 doesn't work for me. This fixes the support. It also passes all the tests (though I didn't run the whole matrix).