### PR TITLE
Update more_like_this helper

### DIFF
--- a/src/django_elasticsearch_dsl_drf/helpers.py
+++ b/src/django_elasticsearch_dsl_drf/helpers.py
@@ -122,7 +122,7 @@ def more_like_this(obj,
         >>>     ['title', 'description', 'summary']
         >>> )
     """
-    _index, _mapping = get_index_and_mapping_for_model(obj._meta.model)
+    _index, _ = get_index_and_mapping_for_model(obj._meta.model)
     if _index is None:
         return None
 
@@ -151,8 +151,7 @@ def more_like_this(obj,
             fields=fields,
             like={
                 '_id': "{}".format(obj.pk),
-                '_index': "{}".format(_index),
-                '_type': "{}".format(_mapping)
+                '_index': "{}".format(_index)
             },
             **kwargs
         )


### PR DESCRIPTION
Remove the `_type` from the like structure.
`_type` is deprecated on Elasticsearch 7.x.

https://www.elastic.co/guide/en/elasticsearch/reference/7.3/query-dsl-mlt-query.html