### PR TITLE
Fix compatibility with django-elasticsearch-dsl 7.1.1

### DIFF
--- a/examples/requirements/elastic_7x.txt
+++ b/examples/requirements/elastic_7x.txt
@@ -1,5 +1,3 @@
 elasticsearch==7.0.2
 elasticsearch-dsl==7.0.0
-#django-elasticsearch-dsl==7.1.1
-https://github.com/sabricot/django-elasticsearch-dsl/archive/3f6cf53d9a2a5da5c7fca7e444b772d3c72f2594.zip
-#https://github.com/sabricot/django-elasticsearch-dsl/archive/f24ba3a86152f13e7181f0afa01ab6dee0d70400.zip
+django-elasticsearch-dsl==7.1.1

--- a/examples/simple/factories/factory_faker.py
+++ b/examples/simple/factories/factory_faker.py
@@ -32,6 +32,7 @@ class EnGbFaker(OriginalFaker):
 
 class DjangoUserProvider(BaseProvider):
     """Django user provider."""
+    _fake = FakerFaker()
 
     @classmethod
     def first_name_django(cls, max_length=30):
@@ -55,8 +56,7 @@ class DjangoUserProvider(BaseProvider):
         :return: str.
         """
 
-        fake = FakerFaker()
-        return fake.first_name()[:max_length]
+        return cls._fake.first_name()[:max_length]
 
     @classmethod
     def last_name_django(cls, max_length=30):
@@ -80,8 +80,7 @@ class DjangoUserProvider(BaseProvider):
         :return: str.
         """
 
-        fake = FakerFaker()
-        return fake.last_name()[:max_length]
+        return cls._fake.last_name()[:max_length]
 
 
 Faker.add_provider(DjangoUserProvider)

--- a/examples/simple/settings/testing.py
+++ b/examples/simple/settings/testing.py
@@ -112,3 +112,7 @@ LOGGING = {
         },
     },
 }
+
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.MD5PasswordHasher',
+]

--- a/src/django_elasticsearch_dsl_drf/compat.py
+++ b/src/django_elasticsearch_dsl_drf/compat.py
@@ -51,22 +51,7 @@ __all__ = (
 #         return _get_count(queryset)
 
 
-def keyword_field(**kwargs):
-    """Keyword field.
-
-    :param kwargs:
-    :return:
-    """
-    major = get_elasticsearch_version()[0]
-    if major > 2:
-        return fields.KeywordField(**kwargs)
-    else:
-        if 'analyzer' not in kwargs:
-            kwargs['analyzer'] = 'keyword'
-        return fields.StringField(**kwargs)
-
-
-KeywordField = keyword_field
+KeywordField = fields.KeywordField
 
 
 def string_field(**kwargs):
@@ -75,13 +60,8 @@ def string_field(**kwargs):
     :param kwargs:
     :return:
     """
-    major = get_elasticsearch_version()[0]
-    if major > 2:
-        if 'fielddata' not in kwargs:
-            kwargs['fielddata'] = True
-        return fields.StringField(**kwargs)
-    else:
-        return fields.StringField(**kwargs)
+    kwargs.setdefault('fielddata', True)
+    return fields.TextField(**kwargs)
 
 
 StringField = string_field

--- a/src/django_elasticsearch_dsl_drf/serializers.py
+++ b/src/django_elasticsearch_dsl_drf/serializers.py
@@ -109,7 +109,6 @@ class DocumentSerializer(
     _abstract = True
 
     _field_mapping = {
-        fields.AttachmentField: CharField,  # Removed from Elasticsearch 6.x
         fields.BooleanField: BooleanField,
         fields.ByteField: CharField,  # TODO
         fields.CompletionField: CharField,  # TODO
@@ -125,21 +124,10 @@ class DocumentSerializer(
         fields.ListField: ListField,
         fields.ObjectField: ObjectField,
         fields.ShortField: IntegerField,
-        fields.StringField: CharField,  # Removed in Elasticsearch 6.x
         fields.FileField: CharField,  # TODO
-    }
-
-    # Elasticsearch 5.x specific fields
-    try:
-        _field_mapping.update(
-            {
-                fields.KeywordField: CharField,
-                fields.TextField: CharField
-            }
-        )
-
-    except AttributeError:
-        pass
+        fields.KeywordField: CharField,
+        fields.TextField: CharField,
+        }
 
     def __init__(self, instance=None, data=empty, **kwargs):
         super(DocumentSerializer, self).__init__(instance, data, **kwargs)


### PR DESCRIPTION
django-elasticsearch-dsl 7.1.1 dropped `StringField` which breaks this package. I removed the uses and a future version should probably drop it altogether. The only need for it at the moment is the implicit `fielddata` default.