### PR TITLE
Skip duplicate suggestions

### DIFF
--- a/src/django_elasticsearch_dsl_drf/filter_backends/suggester/native.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/suggester/native.py
@@ -435,6 +435,8 @@ class SuggesterFilterBackend(BaseFilterBackend, FilterBackendMixin):
             completion_kwargs['size'] = options['size']
         if 'contexts' in options:
             completion_kwargs['contexts'] = options['contexts']
+        if 'skip_duplicates' in options:
+            completion_kwargs['skip_duplicates'] = options['skip_duplicates']
         return queryset.suggest(
             suggester_name,
             value,


### PR DESCRIPTION
Adding new feature skip duplicate suggestions 

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html#skip_duplicates

usage:

```
    suggester_fields = {
        'name_suggest': {
            'field': 'name.suggest',
            'suggesters': [
                SUGGESTER_COMPLETION,
                SUGGESTER_TERM,
                SUGGESTER_PHRASE
            ],
            'options': {
                'size': 20,
                'skip_duplicates':True 
            },
        },
    }

```


Can someone please test it and let me know, if it pass I'll update the documents . 

Thanks


