### PR TITLE
Allow __all__ to be specified as fields in DocumentSerializer

### DIFF
--- a/src/django_elasticsearch_dsl_drf/serializers.py
+++ b/src/django_elasticsearch_dsl_drf/serializers.py
@@ -197,6 +197,11 @@ class DocumentSerializer(
         declared_fields = copy.deepcopy(self._declared_fields)
         field_mapping = OrderedDict()
 
+        # Match drf convention of specifying "__all__" for all available fields
+        # This is the existing behavior so we can ignore this value.
+        if __fields == "__all__":
+            __fields = None
+
         for field_name, field_type in six.iteritems(document_fields):
             orig_name = field_name[:]
 


### PR DESCRIPTION
This is purely for cosmetic reasons allowing the drf convention to be
used and increasing the readability of the code by allowing people to
see that the expected fields will be "all".