### PR TITLE
Use empty tuple instead of None in serializers fields __all__

### DIFF
--- a/src/django_elasticsearch_dsl_drf/serializers.py
+++ b/src/django_elasticsearch_dsl_drf/serializers.py
@@ -200,7 +200,7 @@ class DocumentSerializer(
         # Match drf convention of specifying "__all__" for all available fields
         # This is the existing behavior so we can ignore this value.
         if __fields == "__all__":
-            __fields = None
+            __fields = ()
 
         for field_name, field_type in six.iteritems(document_fields):
             orig_name = field_name[:]


### PR DESCRIPTION
The __fields value may be used elsewhere and it isn't expecting it to be
None, rather an empty tuple. For example in sort_by_list later on.