### PR TITLE
Bug-fix: Popping of the `path` option

### DIFF
--- a/src/django_elasticsearch_dsl_drf/filter_backends/filtering/nested.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/filtering/nested.py
@@ -177,12 +177,10 @@ class NestedFilteringFilterBackend(FilteringFilterBackend):
         :param kwargs:
         :return:
         """
-        if options is None:
+        if options is None or 'path' not in options:
             raise ImproperlyConfigured(
                 "You should provide an `path` argument in the field options."
             )
-
-        path = options.pop('path')
 
         if args is None:
             args = []
@@ -191,7 +189,7 @@ class NestedFilteringFilterBackend(FilteringFilterBackend):
 
         return queryset.query(
             'nested',
-            path=path,
+            path=options.get('path'),
             query=Q(*args, **kwargs)
         )
 


### PR DESCRIPTION
**Context:**

If you request a filter multiple times such as: 

`?field__lte=20&field__lte=30`

This will create a list of values as shown below, and the `path` will be popped and on the second iteration, this will cause an unhandled `KeyError` exception.

`{'field__lte': {'lookup': 'lte', 'values': ['20', '30'], 'field': 'field.value', 'type': 'doc', 'path': 'path'}}`