### PR TITLE
debug on getting objects when lookup_field != 'id'

### DIFF
--- a/src/django_elasticsearch_dsl_drf/viewsets.py
+++ b/src/django_elasticsearch_dsl_drf/viewsets.py
@@ -221,7 +221,7 @@ class BaseDocumentViewSet(ReadOnlyModelViewSet):
         else:
             queryset = queryset.filter(
                 'term',
-                **{self.document_uid_field: self.kwargs[lookup_url_kwarg]}
+                **{lookup_url_kwarg: self.kwargs[lookup_url_kwarg]}
             )
 
             hits = queryset.execute().hits.hits


### PR DESCRIPTION
This way, the viewset can be used by Elasticsearch-dsl users. In the previous version, regardless of what the lookup field is, it uses the document uid.
(users that their model is not a Django model. For example, I am using mongo)