### PR TITLE
reduce ES hits in paginator from 2 to 1

### DIFF
--- a/src/django_elasticsearch_dsl_drf/pagination.py
+++ b/src/django_elasticsearch_dsl_drf/pagination.py
@@ -33,7 +33,7 @@ __all__ = (
 
 class GetCountMixin:
 
-    def get_count(self, es_response):
+    def get_es_count(self, es_response):
         if isinstance(es_response, list):
             return len(es_response)
         if isinstance(es_response.hits.total, AttrDict):
@@ -46,7 +46,7 @@ class Page(django_paginator.Page, GetCountMixin):
 
     def __init__(self, object_list, number, paginator, facets):
         self.facets = facets
-        self.count = self.get_count(object_list)
+        self.count = self.get_es_count(object_list)
         super(Page, self).__init__(object_list, number, paginator)
 
 
@@ -62,7 +62,7 @@ class Paginator(django_paginator.Paginator, GetCountMixin):
         bottom = (number - 1) * self.per_page
         top = bottom + self.per_page
         object_list = self.object_list[bottom:top].execute()
-        self.count = int(self.get_count(object_list))
+        self.count = int(self.get_es_count(object_list))
         if self.count > top and self.count - top <= self.orphans:
             # Fetch the additional orphaned nodes
             object_list = list(object_list) + list(self.object_list[top:self.count].execute())
@@ -257,13 +257,13 @@ class LimitOffsetPagination(pagination.LimitOffsetPagination, GetCountMixin):
         # If we got to this point, it means it's not a suggest or functional
         # suggest case.
 
-        # if hasattr(self, 'get_count'):
-        #     self.count = self.get_count(queryset)
+        # if hasattr(self, 'get_es_count'):
+        #     self.count = self.get_es_count(queryset)
         # else:
         #     from rest_framework.pagination import _get_count
         #     self.count = _get_count(queryset)
 
-        # self.count = get_count(self, queryset)
+        # self.count = get_es_count(self, queryset)
 
         self.limit = self.get_limit(request)
         if self.limit is None:
@@ -275,7 +275,7 @@ class LimitOffsetPagination(pagination.LimitOffsetPagination, GetCountMixin):
         resp = queryset[self.offset:self.offset + self.limit].execute()
         self.facets = getattr(resp, 'aggregations', None)
 
-        self.count = self.get_count(resp)
+        self.count = self.get_es_count(resp)
 
         if self.count > self.limit and self.template is not None:
             self.display_page_controls = True

--- a/src/django_elasticsearch_dsl_drf/pagination.py
+++ b/src/django_elasticsearch_dsl_drf/pagination.py
@@ -95,6 +95,7 @@ class PageNumberPagination(pagination.PageNumberPagination, GetCountMixin):
 
     django_paginator_class = Paginator
     page_size_query_param = 'page_size'
+    orphans_query_param = 'orphans'
 
     def __init__(self, *args, **kwargs):
         """Constructor.
@@ -156,7 +157,8 @@ class PageNumberPagination(pagination.PageNumberPagination, GetCountMixin):
         if not page_size:
             return None
 
-        paginator = self.django_paginator_class(queryset, page_size)
+        orphans = min(int(request.query_params.get(self.orphans_query_param, 0)), page_size)
+        paginator = self.django_paginator_class(queryset, page_size, orphans=orphans)
         page_number = request.query_params.get(self.page_query_param, 1)
         if page_number in self.last_page_strings:
             page_number = paginator.num_pages

--- a/src/django_elasticsearch_dsl_drf/pagination.py
+++ b/src/django_elasticsearch_dsl_drf/pagination.py
@@ -48,7 +48,7 @@ class Page(django_paginator.Page, GetCountMixin):
         super(Page, self).__init__(object_list, number, paginator)
 
 
-class Paginator(django_paginator.Paginator):
+class Paginator(django_paginator.Paginator, GetCountMixin):
     """Paginator for Elasticsearch."""
 
     def page(self, number):
@@ -60,7 +60,7 @@ class Paginator(django_paginator.Paginator):
         bottom = (number - 1) * self.per_page
         top = bottom + self.per_page
         object_list = self.object_list[bottom:top].execute()
-        self.count = int(object_list.hits.total)
+        self.count = int(self.get_count(object_list))
         number = self.validate_number(number)
         __facets = getattr(object_list, 'aggregations', None)
         return self._get_page(object_list, number, self, facets=__facets)

--- a/src/django_elasticsearch_dsl_drf/pagination.py
+++ b/src/django_elasticsearch_dsl_drf/pagination.py
@@ -57,12 +57,11 @@ class Paginator(django_paginator.Paginator):
         :param number:
         :return:
         """
-        number = self.validate_number(number)
         bottom = (number - 1) * self.per_page
         top = bottom + self.per_page
-        if top + self.orphans >= self.count:
-            top = self.count
         object_list = self.object_list[bottom:top].execute()
+        self.count = int(object_list.hits.total)
+        number = self.validate_number(number)
         __facets = getattr(object_list, 'aggregations', None)
         return self._get_page(object_list, number, self, facets=__facets)
 

--- a/src/django_elasticsearch_dsl_drf/pagination.py
+++ b/src/django_elasticsearch_dsl_drf/pagination.py
@@ -94,6 +94,7 @@ class PageNumberPagination(pagination.PageNumberPagination, GetCountMixin):
     """
 
     django_paginator_class = Paginator
+    page_size_query_param = 'page_size'
 
     def __init__(self, *args, **kwargs):
         """Constructor.

--- a/src/django_elasticsearch_dsl_drf/pagination.py
+++ b/src/django_elasticsearch_dsl_drf/pagination.py
@@ -159,7 +159,7 @@ class PageNumberPagination(pagination.PageNumberPagination, GetCountMixin):
 
         orphans = min(int(request.query_params.get(self.orphans_query_param, 0)), page_size)
         paginator = self.django_paginator_class(queryset, page_size, orphans=orphans)
-        page_number = request.query_params.get(self.page_query_param, 1)
+        page_number = int(request.query_params.get(self.page_query_param, 1))
         if page_number in self.last_page_strings:
             page_number = paginator.num_pages
 


### PR DESCRIPTION
The paginator initiates COUNT requests to ElasticSearch, that are not necessary, because the count is returned by the full query.
This modification takes the result count from the query and uses it for validation resulting in only on ES hit per request.