### PR TITLE
setup.py: Replace fake-factory with Faker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,7 @@ extras_require = []
 
 tests_require = [
     'factory_boy',
-    'fake-factory',
+    'Faker',
     'pytest',
     'pytest-django',
     'pytest-cov',


### PR DESCRIPTION
fake-factory is deprecated by Faker.