### PR TITLE
Set default_app_config only in Django 3.1 or less

### DIFF
--- a/src/django_elasticsearch_dsl_drf/__init__.py
+++ b/src/django_elasticsearch_dsl_drf/__init__.py
@@ -9,5 +9,7 @@ __copyright__ = '2017-2020 Artur Barseghyan'
 __license__ = 'GPL 2.0/LGPL 2.1'
 __all__ = ('default_app_config',)
 
+import django
+
 if django.VERSION < (3, 2):
     default_app_config = 'django_elasticsearch_dsl_drf.apps.Config'

--- a/src/django_elasticsearch_dsl_drf/__init__.py
+++ b/src/django_elasticsearch_dsl_drf/__init__.py
@@ -9,4 +9,5 @@ __copyright__ = '2017-2020 Artur Barseghyan'
 __license__ = 'GPL 2.0/LGPL 2.1'
 __all__ = ('default_app_config',)
 
-default_app_config = 'django_elasticsearch_dsl_drf.apps.Config'
+if django.VERSION < (3, 2):
+    default_app_config = 'django_elasticsearch_dsl_drf.apps.Config'


### PR DESCRIPTION
https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery

default_app_config is deprecated starting in 3.2, so a project in that version using this library with Deprecation Warnings enabled gets a warning about it.

This pull request sets the variable only if the Django version is previous to 3.2