### PR TITLE
Fix viewset "get_object" method for non-standard lookup field

### DIFF
--- a/examples/simple/search_indexes/documents/__init__.py
+++ b/examples/simple/search_indexes/documents/__init__.py
@@ -5,7 +5,7 @@ from .city import CityDocument
 from .journal import JournalDocument
 from .location import LocationDocument
 from .publisher import PublisherDocument
-from .tag import TagDocument
+from .tag import TagDocument, NoKeywordTagDocument
 
 __all___ = (
     'AddressDocument',
@@ -14,4 +14,5 @@ __all___ = (
     'CityDocument',
     'PublisherDocument',
     'TagDocument',
+    'NoKeywordTagDocument',
 )

--- a/examples/simple/search_indexes/documents/tag.py
+++ b/examples/simple/search_indexes/documents/tag.py
@@ -1,11 +1,13 @@
 from django.conf import settings
 from django_elasticsearch_dsl import Document, Index, fields
+from django_elasticsearch_dsl.registries import registry
 
 from books.models import Tag
 from .analyzers import html_strip
 
 
-__all__ = ('TagDocument',)
+__all__ = ('TagDocument',
+           'NoKeywordTagDocument')
 
 INDEX = Index(settings.ELASTICSEARCH_INDEX_NAMES[__name__])
 
@@ -23,6 +25,31 @@ class TagDocument(Document):
     # Set unique title as the document id.
     id = fields.KeywordField(attr='title')
     title = fields.KeywordField()
+
+    class Django(object):
+        """Django Elasticsearch DSL ORM Meta."""
+
+        model = Tag
+
+    class Meta:
+        """Meta options."""
+
+        parellel_indexing = True
+
+
+@registry.register_document
+class NoKeywordTagDocument(Document):
+    """Elasticsearch document for a Tag."""
+
+    id = fields.IntegerField()
+    title = fields.TextField()
+
+    class Index:
+        name = "test_no_keyword_tag"
+        settings = {
+            'number_of_shards': 1,
+            'number_of_replicas': 0,
+        }
 
     class Django(object):
         """Django Elasticsearch DSL ORM Meta."""

--- a/examples/simple/search_indexes/serializers/__init__.py
+++ b/examples/simple/search_indexes/serializers/__init__.py
@@ -11,7 +11,7 @@ from .publisher import (
     PublisherDocumentSerializer,
     PublisherDocumentSimpleSerializer,
 )
-from .tag import TagDocumentSerializer
+from .tag import TagDocumentSerializer, NoKeywordTagDocumentSerializer
 
 __all__ = (
     'AddressDocumentSerializer',
@@ -25,4 +25,5 @@ __all__ = (
     'PublisherDocumentSerializer',
     'PublisherDocumentSimpleSerializer',
     'TagDocumentSerializer',
+    'NoKeywordTagDocumentSerializer',
 )

--- a/examples/simple/search_indexes/serializers/tag.py
+++ b/examples/simple/search_indexes/serializers/tag.py
@@ -1,9 +1,10 @@
 from django_elasticsearch_dsl_drf.serializers import DocumentSerializer
 
-from ..documents import TagDocument
+from ..documents import TagDocument, NoKeywordTagDocument
 
 
-__all__ = ('TagDocumentSerializer',)
+__all__ = ('TagDocumentSerializer',
+           'NoKeywordTagDocumentSerializer')
 
 
 class TagDocumentSerializer(DocumentSerializer):
@@ -13,6 +14,19 @@ class TagDocumentSerializer(DocumentSerializer):
         """Meta options."""
 
         document = TagDocument
+        fields = (
+            'id',
+            'title',
+        )
+
+
+class NoKeywordTagDocumentSerializer(DocumentSerializer):
+    """Serializer for a Tag document."""
+
+    class Meta:
+        """Meta options."""
+
+        document = NoKeywordTagDocument
         fields = (
             'id',
             'title',

--- a/examples/simple/search_indexes/urls.py
+++ b/examples/simple/search_indexes/urls.py
@@ -32,6 +32,7 @@ from .viewsets import (
     PublisherDocumentViewSet,
     QueryFriendlyPaginationBookDocumentViewSet,
     TagDocumentViewSet,
+    NoKeywordTagDocumentViewSet,
 )
 
 __all__ = ('urlpatterns',)
@@ -250,6 +251,12 @@ router.register(
     r'tags',
     TagDocumentViewSet,
     basename='tagdocument'
+)
+
+router.register(
+    r'nokeywordtags',
+    NoKeywordTagDocumentViewSet,
+    basename='nokeywordtagdocument'
 )
 
 # **********************************************************

--- a/examples/simple/search_indexes/viewsets/__init__.py
+++ b/examples/simple/search_indexes/viewsets/__init__.py
@@ -39,4 +39,5 @@ __all__ = (
     'PublisherDocumentViewSet',
     'QueryFriendlyPaginationBookDocumentViewSet',
     'TagDocumentViewSet',
+    'NoKeywordTagDocumentViewSet',
 )

--- a/examples/simple/search_indexes/viewsets/tag.py
+++ b/examples/simple/search_indexes/viewsets/tag.py
@@ -1,11 +1,12 @@
 from django_elasticsearch_dsl_drf.pagination import LimitOffsetPagination
 from django_elasticsearch_dsl_drf.viewsets import DocumentViewSet
 
-from ..documents import TagDocument
-from ..serializers import TagDocumentSerializer
+from ..documents import TagDocument, NoKeywordTagDocument
+from ..serializers import TagDocumentSerializer, NoKeywordTagDocumentSerializer
 
 __all__ = (
     'TagDocumentViewSet',
+    'NoKeywordTagDocumentViewSet'
 )
 
 
@@ -15,5 +16,16 @@ class TagDocumentViewSet(DocumentViewSet):
     document = TagDocument
     serializer_class = TagDocumentSerializer
     lookup_field = 'title'
+    filter_backends = []
+    pagination_class = LimitOffsetPagination
+
+
+class NoKeywordTagDocumentViewSet(DocumentViewSet):
+    """Document viewset for tags."""
+
+    document = NoKeywordTagDocument
+    serializer_class = NoKeywordTagDocumentSerializer
+    lookup_field = 'title'
+    document_uid_field = 'title'
     filter_backends = []
     pagination_class = LimitOffsetPagination

--- a/src/django_elasticsearch_dsl_drf/tests/test_elasticsearch_helpers.py
+++ b/src/django_elasticsearch_dsl_drf/tests/test_elasticsearch_helpers.py
@@ -47,6 +47,7 @@ class TestElasticsearchHelpers(BaseTestCase):
             'test_author',
             'test_book',
             'test_tag',
+            'test_no_keyword_tag',
         }
 
         self.assertSetEqual(res, expected)

--- a/src/django_elasticsearch_dsl_drf/tests/test_management_commands.py
+++ b/src/django_elasticsearch_dsl_drf/tests/test_management_commands.py
@@ -47,6 +47,7 @@ class TestManagementCommands(BaseTestCase):
             'test_author',
             'test_book',
             'test_tag',
+            'test_no_keyword_tag',
         }
 
         self.assertSetEqual(res, expected)

--- a/src/django_elasticsearch_dsl_drf/tests/test_views.py
+++ b/src/django_elasticsearch_dsl_drf/tests/test_views.py
@@ -78,6 +78,16 @@ class TestViews(BaseRestFrameworkTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['id'], __obj.title)
 
+    def test_detail_view_with_custom_lookup_no_keywords(self):
+        """Test detail view with a custom lookup field."""
+        __obj = self.tags[0]
+        url = reverse('nokeywordtagdocument-detail', kwargs={'title': __obj.title})
+        data = {}
+
+        response = self.client.get(url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['title'], __obj.title)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/django_elasticsearch_dsl_drf/viewsets.py
+++ b/src/django_elasticsearch_dsl_drf/viewsets.py
@@ -10,7 +10,7 @@ import copy
 from django.http import Http404
 from django.core.exceptions import ImproperlyConfigured
 
-from elasticsearch_dsl import Search
+from elasticsearch_dsl import Search, Q
 from elasticsearch_dsl.connections import connections
 from elasticsearch_dsl.query import MoreLikeThis
 
@@ -225,10 +225,11 @@ class BaseDocumentViewSet(ReadOnlyModelViewSet):
             )
             return dictionary_proxy
         else:
-            queryset = queryset.filter(
-                'term',
-                **{self.document_uid_field: self.kwargs[lookup_url_kwarg]}
-            )
+            queryset.query = Q(
+                'bool', must=[
+                    Q('match',
+                      **{self.document_uid_field:
+                         self.kwargs[lookup_url_kwarg]})])
 
             hits = queryset.execute().hits.hits
             count = len(hits)


### PR DESCRIPTION
In the current implementation, if you want to lookup a single record by a value in the URL, and the lookup field is not called `id`, it will return no results.

For example I have a document called Car, with fields `id`, `license_plate`, `make`, and `model`. I set the `lookup_field` and `document_uid_field` both to `license_plate` in my viewset (which extends DocumentViewSet). If I make a request to the url `https://api.mydomain.com/cars/OUTATIME` using the current implementation, I receive no results even if I have a Car document with that `license_plate` in the index.

This fix makes it so I get the result as expected, by using an ElasticSerach must/match query rather than filter/term