### PR TITLE
Nested search documentation fix

### DIFF
--- a/src/django_elasticsearch_dsl_drf/filter_backends/search/historical.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/search/historical.py
@@ -90,11 +90,11 @@ class SearchFilterBackend(BaseFilterBackend, FilterBackendMixin):
         >>> search_nested_fields = {
         >>>     'country': {
         >>>         'path': 'country',
-        >>>         'fields': [{'name': {'boost': 2}}]
+        >>>         'fields': [{'name': 'name', 'boost': 2}]
         >>>     },
         >>>     'city': {
         >>>         'path': 'country.city',
-        >>>         'fields': [{'name': {'boost': 2}}]
+        >>>         'fields': [{'name': 'name', 'boost': 2}]
         >>>     },
         >>> }
 

--- a/src/django_elasticsearch_dsl_drf/filter_backends/search/query_backends/nested.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/search/query_backends/nested.py
@@ -43,11 +43,11 @@ class NestedQueryBackend(BaseSearchQueryBackend):
             search_nested_fields = {
                 'country': {
                     'path': 'country',
-                    'fields': [{'name': {'boost': 2}}]
+                    'fields': [{'name': 'name', 'boost': 2}]
                 },
                 'city': {
                     'path': 'country.city',
-                    'fields': [{'name': {'boost': 2}}]
+                    'fields': [{'name': 'name', 'boost': 2}]
                 },
             }
 
@@ -76,7 +76,8 @@ class NestedQueryBackend(BaseSearchQueryBackend):
                         # In case if we deal with structure 2
                         if isinstance(_field, dict):
                             # take options (ex: boost) into consideration
-                            field_options = {key: value for key, value in _field.items() if key != 'name'}
+                            field_options = {
+                                key: value for key, value in _field.items() if key != 'name'}
                             field_options.update({
                                 "query": search_term,
                             })
@@ -111,7 +112,8 @@ class NestedQueryBackend(BaseSearchQueryBackend):
                         # In case if we deal with structure 2
                         if isinstance(_field, dict):
                             # take options (ex: boost) into consideration
-                            field_options = {key: value for key, value in _field.items() if key != 'name'}
+                            field_options = {
+                                key: value for key, value in _field.items() if key != 'name'}
                             field_options.update({
                                 "query": search_term,
                             })


### PR DESCRIPTION
**Fix:**

- Updated the example of nested search in SearchFilterBackend.
- Updated the example of nested search in CompoundSearchFilterBackend.

**Issue:**

- Example shown in the nested search constructs the query like this : 
`[Nested(path=country, query=Match(country__{'boost': 2}={'query': 'example'}))]`
when it is supposed to construct it like this:
`[Nested(path=country, query=Match(country__name={'boost': 2, 'query': 'example'}))]`