### PR TITLE
Allow custom field name in HighlightBackend

### DIFF
--- a/src/django_elasticsearch_dsl_drf/filter_backends/highlight.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/highlight.py
@@ -124,6 +124,7 @@ class HighlightBackend(BaseFilterBackend):
         highlight_fields = self.prepare_highlight_fields(view)
         for __field, __options in highlight_fields.items():
             if __field in highlight_query_params or __options['enabled']:
-                queryset = queryset.highlight(__field, **__options['options'])
+                __field_name = __options.get("field", __field_name)
+                queryset = queryset.highlight(__field_name, **__options['options'])
 
         return queryset


### PR DESCRIPTION
Allow custom field name in `HighlightBackend`.

```python
    highlight_fields = {
        "body": {"enabled": True, "options": {"fragment_size": 50, "number_of_fragments": 1_000}},
        "name": {"field": "name.text", "enabled": True, "options": {"fragment_size": 50, "number_of_fragments": 1_000}},
    }
```