### PR TITLE
AggsProxy import problem fixed.

### DIFF
--- a/src/django_elasticsearch_dsl_drf/utils.py
+++ b/src/django_elasticsearch_dsl_drf/utils.py
@@ -3,7 +3,7 @@ Utils.
 """
 
 import datetime
-from elasticsearch_dsl.search import AggsProxy
+from elasticsearch_dsl.search_base import AggsProxy
 
 
 __title__ = 'django_elasticsearch_dsl_drf.utils'


### PR DESCRIPTION
When I updated the django-elasticsearch-dsl version from version 7.2.2 to version 8.0 for my own project, I received an error that the AggsProxy class could not be imported.
The error encountered with this commit has been fixed.