### PR TITLE
Fix AggsProxy can't be imported | functional.py | utils.py (Tested with elasticsearch-dsl==8.13.1 & django==5.0.4)

### DIFF
--- a/src/django_elasticsearch_dsl_drf/filter_backends/suggester/functional.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/suggester/functional.py
@@ -67,7 +67,7 @@ Example:
     >>>
     >>>         model = Publisher  # The model associate with this Document
 """
-from elasticsearch_dsl.search import AggsProxy
+from elasticsearch_dsl.search_base import AggsProxy
 
 from django_elasticsearch_dsl_drf.constants import (
     FUNCTIONAL_SUGGESTER_TERM_MATCH,

--- a/src/django_elasticsearch_dsl_drf/utils.py
+++ b/src/django_elasticsearch_dsl_drf/utils.py
@@ -3,7 +3,7 @@ Utils.
 """
 
 import datetime
-from elasticsearch_dsl.search import AggsProxy
+from elasticsearch_dsl.search_base import AggsProxy
 
 
 __title__ = 'django_elasticsearch_dsl_drf.utils'


### PR DESCRIPTION
**Adding the fork below to your requirements.txt file can be a quick solution until this pull request is accepted**

> git+https://github.com/abdelslam1997/django-elasticsearch-dsl-drf.git@master