### PR TITLE
Solve the problem of the cannot import name 'AggsProxy' from elasticsearch_dsl.search #314

### DIFF
--- a/src/django_elasticsearch_dsl_drf/utils.py
+++ b/src/django_elasticsearch_dsl_drf/utils.py
@@ -3,7 +3,7 @@ Utils.
 """
 
 import datetime
-from elasticsearch_dsl.search import AggsProxy
+from elasticsearch_dsl.search_base import AggsProxy
 
 
 __title__ = 'django_elasticsearch_dsl_drf.utils'


### PR DESCRIPTION
Edit the file utils.py and replace the "from elasticsearch_dsl.search import AggsProxy" with the "from elasticsearch_dsl.search_base import AggsProxy"


It will be very  use full if You just merge it with the main brach.