### PR TITLE
Fix AggsProxy import with elasticsearch-dsl team approach

### DIFF
--- a/src/django_elasticsearch_dsl_drf/filter_backends/suggester/functional.py
+++ b/src/django_elasticsearch_dsl_drf/filter_backends/suggester/functional.py
@@ -67,7 +67,15 @@ Example:
     >>>
     >>>         model = Publisher  # The model associate with this Document
 """
-from elasticsearch_dsl.search import AggsProxy
+try: # code for 8.13 (requires 8.13.1)
+    # This should not be imported in external projects, as it is a internal tool.
+    # See https://github.com/barseghyanartur/django-elasticsearch-dsl-drf/pull/316/files#r1596499499
+    from elasticsearch_dsl.search_base import AggsProxy
+except ImportError:
+    # backward-compatible (older than 8.13)
+    from elasticsearch_dsl.search import AggsProxy
+
+from elasticsearch_dsl.search_base import AggsProxy
 
 from django_elasticsearch_dsl_drf.constants import (
     FUNCTIONAL_SUGGESTER_TERM_MATCH,

--- a/src/django_elasticsearch_dsl_drf/utils.py
+++ b/src/django_elasticsearch_dsl_drf/utils.py
@@ -3,7 +3,6 @@ Utils.
 """
 
 import datetime
-from elasticsearch_dsl.search import AggsProxy
 
 
 __title__ = 'django_elasticsearch_dsl_drf.utils'
@@ -15,40 +14,45 @@ __all__ = (
     'EmptySearch',
 )
 
+try:
+    # code for 8.13 (requires 8.13.1)
+    from elasticsearch_dsl import EmptySearch
+except ImportError:
+    from elasticsearch_dsl.search import AggsProxy
 
-class EmptySearch(object):
-    """Empty Search."""
+    class EmptySearch(object):
+        """Empty Search."""
 
-    def __init__(self, *args, **kwargs):
-        self.aggs = AggsProxy('')
-        self._highlight = {}
-        self._sort = []
-        self.total = 0
+        def __init__(self, *args, **kwargs):
+            self.aggs = AggsProxy('')
+            self._highlight = {}
+            self._sort = []
+            self.total = 0
 
-    def __len__(self):
-        return 0
+        def __len__(self):
+            return 0
 
-    def __iter__(self):
-        return iter([])
+        def __iter__(self):
+            return iter([])
 
-    def __getitem__(self, *args, **kwargs):
-        return self
+        def __getitem__(self, *args, **kwargs):
+            return self
 
-    def highlight(self, *args, **kwargs):
-        return self
+        def highlight(self, *args, **kwargs):
+            return self
 
-    def sort(self, *args, **kwargs):
-        return self
+        def sort(self, *args, **kwargs):
+            return self
 
-    @property
-    def hits(self):
-        return self
+        @property
+        def hits(self):
+            return self
 
-    def execute(self, *args, **kwargs):
-        return self
+        def execute(self, *args, **kwargs):
+            return self
 
-    def to_dict(self, *args, **kwargs):
-        return {}
+        def to_dict(self, *args, **kwargs):
+            return {}
 
 
 class DictionaryProxy(object):


### PR DESCRIPTION
See [this comment](https://github.com/barseghyanartur/django-elasticsearch-dsl-drf/pull/316#discussion_r1596499499) by @miguelgrinberg (elasticsearch-dsl team @ Elastic).

This PR fixes the import issue in a future-proof way, while still being backward compatible.

```
AggsProxy can't be imported | functional.py | utils.py (Tested with elasticsearch-dsl==8.13.1 & django==5.0.4)
```

## Testing instructions:
- Remove the old version of django-elasticsearch-dsl-drf from a project that generates this error
```
pip uninstall django-elasticsearch-dsl-drf
```
- Install this version
```
 pip install git+https://github.com/millerf/django-elasticsearch-dsl-drf@fix/aggs-proxy-import-error 
```

Run the server or some tests and verify it works.

Should fix #314  and close #315 #316 #318 (that took the same non-future-proof approach) 


